### PR TITLE
Improved code of "add product to th cart" and " place order" endpoints

### DIFF
--- a/code/orders-api-rest/api/openapi-rest.yml
+++ b/code/orders-api-rest/api/openapi-rest.yml
@@ -105,14 +105,7 @@ paths:
         - Orders
       summary: Place an order
       parameters:
-        - in: path
-          name: userId
-          required: true
-          schema:
-            type: integer
-            description: Id of the user
-            format: int64
-          example: '1'
+        - $ref: '#/components/parameters/UserId'
       operationId: placeOrder
       security:
         - bearerAuth: [ ]
@@ -195,7 +188,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/PageProducts'
 
-  /v1/cart/{productId}/{userId}:
+  /v1/users/{userId}/cart/{productId}:
     post:
       tags:
         - Cart
@@ -213,13 +206,7 @@ paths:
             format: uuid
             example: '8efbee82-8a0c-407a-a4c0-16bbad40a23e'
           description: The id of the product which is added to the cart
-        - in: path
-          name: userId
-          required: true
-          schema:
-            type: string
-            format: long
-          description: The id of the user who added the product
+        - $ref: '#/components/parameters/UserId'
       responses:
         '201':
           description: The card with added products was created

--- a/code/orders-api-rest/src/test/java/com/academy/orders/apirest/TestConstants.java
+++ b/code/orders-api-rest/src/test/java/com/academy/orders/apirest/TestConstants.java
@@ -21,4 +21,7 @@ public class TestConstants {
 	public static final String TEST_CITY = "mockedCity";
 	public static final String TEST_DEPARTMENT = "mockedDepartment";
 
+	public static final String ADMIN_ROLE = "ADMIN";
+	public static final String USER_ROLE = "USER";
+
 }

--- a/code/orders-api-rest/src/test/java/com/academy/orders/apirest/TestSecurityUtil.java
+++ b/code/orders-api-rest/src/test/java/com/academy/orders/apirest/TestSecurityUtil.java
@@ -1,0 +1,17 @@
+package com.academy.orders.apirest;
+
+import java.util.Arrays;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+
+public class TestSecurityUtil {
+	public static RequestPostProcessor jwtAuth(long userId, String... roles) {
+		var grantedRoles = Arrays.stream(roles).map(SimpleGrantedAuthority::new).map(GrantedAuthority.class::cast)
+				.toList();
+
+		return SecurityMockMvcRequestPostProcessors.jwt().jwt(builder -> builder.claim("id", userId))
+				.authorities(grantedRoles);
+	}
+}

--- a/code/orders-api-rest/src/test/java/com/academy/orders/apirest/auth/controller/AuthTokenControllerTest.java
+++ b/code/orders-api-rest/src/test/java/com/academy/orders/apirest/auth/controller/AuthTokenControllerTest.java
@@ -7,6 +7,7 @@ import com.academy.orders.domain.account.entity.CreateAccountDTO;
 import com.academy.orders.domain.account.usecase.CreateUserAccountUseCase;
 import com.academy.orders_api_rest.generated.model.SignInRequestDTO;
 import com.academy.orders_api_rest.generated.model.SignUpRequestDTO;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -24,7 +25,6 @@ import org.springframework.security.oauth2.jwt.JwtEncoder;
 import org.springframework.security.oauth2.jwt.JwtEncoderParameters;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
-import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
@@ -38,11 +38,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ContextConfiguration(classes = {AuthTokenController.class})
 @Import(value = {SignUpRequestDTOMapperImpl.class, AopAutoConfiguration.class, TestSecurityConfig.class})
 class AuthTokenControllerTest {
-	private final ObjectMapper objectMapper = new ObjectMapper();
-
+	@Autowired
+	private ObjectMapper objectMapper;
 	@Autowired
 	private MockMvc mockMvc;
-
 	@MockBean
 	private JwtEncoder encoder;
 	@MockBean

--- a/code/orders-api-rest/src/test/java/com/academy/orders/apirest/auth/validator/AccountIdValidatorTest.java
+++ b/code/orders-api-rest/src/test/java/com/academy/orders/apirest/auth/validator/AccountIdValidatorTest.java
@@ -21,7 +21,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-public class AccountIdValidatorTest {
+class AccountIdValidatorTest {
 	@InjectMocks
 	private AccountIdValidator accountIdValidator;
 	@Mock

--- a/code/orders-api-rest/src/test/java/com/academy/orders/apirest/cart/controller/CartItemControllerTest.java
+++ b/code/orders-api-rest/src/test/java/com/academy/orders/apirest/cart/controller/CartItemControllerTest.java
@@ -13,11 +13,12 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
-import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
+import static com.academy.orders.apirest.TestConstants.USER_ROLE;
+import static com.academy.orders.apirest.TestSecurityUtil.jwtAuth;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
@@ -28,7 +29,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 @ContextConfiguration(classes = {CartItemController.class})
 @Import(value = {AopAutoConfiguration.class, TestSecurityConfig.class, ErrorHandler.class})
 class CartItemControllerTest {
-
 	@Autowired
 	private MockMvc mockMvc;
 
@@ -36,22 +36,28 @@ class CartItemControllerTest {
 	private CreateCartItemByUserUseCase cartItemByUserUseCase;
 
 	@Test
-	@WithMockUser(roles = "ADMIN")
 	void testAddProductToCart() throws Exception {
+		var productId = UUID.randomUUID();
+		var userId = 1L;
+
 		doNothing().when(cartItemByUserUseCase).create(any(CreateCartItemDTO.class));
 
-		mockMvc.perform(post("/v1/cart/" + UUID.randomUUID() + "/" + 1L).contentType(MediaType.APPLICATION_JSON))
+		mockMvc.perform(post("/v1/users/{userId}/cart/{productId}", userId, productId)
+				.contentType(MediaType.APPLICATION_JSON).with(jwtAuth(userId, USER_ROLE)))
 				.andExpect(MockMvcResultMatchers.status().isCreated());
 
 		verify(cartItemByUserUseCase).create(any(CreateCartItemDTO.class));
 	}
 
 	@Test
-	@WithMockUser(roles = "ADMIN")
 	void testAddProductToCartThrowsNotFoundException() throws Exception {
+		var productId = UUID.randomUUID();
+		var userId = 1L;
+
 		doThrow(ProductNotFoundException.class).when(cartItemByUserUseCase).create(any(CreateCartItemDTO.class));
 
-		mockMvc.perform(post("/v1/cart/" + UUID.randomUUID() + "/" + 1L).contentType(MediaType.APPLICATION_JSON))
+		mockMvc.perform(post("/v1/users/{userId}/cart/{productId}", userId, productId)
+				.contentType(MediaType.APPLICATION_JSON).with(jwtAuth(userId, USER_ROLE)))
 				.andExpect(MockMvcResultMatchers.status().isNotFound());
 
 		verify(cartItemByUserUseCase).create(any(CreateCartItemDTO.class));

--- a/code/orders-application/pom.xml
+++ b/code/orders-application/pom.xml
@@ -6,8 +6,10 @@
     <artifactId>orders</artifactId>
     <version>1.0.0</version>
   </parent>
-
   <artifactId>orders-application</artifactId>
+  <properties>
+    <spring-tx.version>6.1.8</spring-tx.version>
+  </properties>
 
   <dependencies>
     <dependency>
@@ -18,6 +20,12 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-tx</artifactId>
+      <version>${spring-tx.version}</version>
     </dependency>
   </dependencies>
 

--- a/code/orders-application/pom.xml
+++ b/code/orders-application/pom.xml
@@ -18,14 +18,14 @@
     </dependency>
 
     <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-tx</artifactId>
       <version>${spring-tx.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter</artifactId>
     </dependency>
   </dependencies>
 

--- a/code/orders-application/src/main/java/com/academy/orders/application/order/usecase/CreateOrderUseCaseImpl.java
+++ b/code/orders-application/src/main/java/com/academy/orders/application/order/usecase/CreateOrderUseCaseImpl.java
@@ -18,6 +18,7 @@ import java.util.Objects;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -28,6 +29,7 @@ public class CreateOrderUseCaseImpl implements CreateOrderUseCase {
 	private final CartItemRepository cartItemRepository;
 
 	@Override
+	@Transactional
 	public UUID createOrder(CreateOrderDto createOrderDto, Long accountId) {
 		var order = createOrderObject(createOrderDto);
 		var bucketElements = getBucketElements(accountId);

--- a/code/orders-boot/src/main/java/com/academy/orders/boot/config/SwaggerConfig.java
+++ b/code/orders-boot/src/main/java/com/academy/orders/boot/config/SwaggerConfig.java
@@ -1,0 +1,20 @@
+package com.academy.orders.boot.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+	@Bean
+	public OpenAPI customizeOpenAPI() {
+		final String securitySchemeName = "bearerAuth";
+		return new OpenAPI().addSecurityItem(new SecurityRequirement().addList(securitySchemeName))
+				.components(new Components().addSecuritySchemes(securitySchemeName, new SecurityScheme()
+						.name(securitySchemeName).type(SecurityScheme.Type.HTTP).scheme("bearer").bearerFormat("JWT")))
+				.openapi("3.0.1");
+	}
+}

--- a/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/account/repository/AccountJpaAdapter.java
+++ b/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/account/repository/AccountJpaAdapter.java
@@ -2,11 +2,11 @@ package com.academy.orders.infrastructure.account.repository;
 
 import com.academy.orders.infrastructure.account.entity.AccountEntity;
 import java.util.Optional;
-import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface AccountJpaAdapter extends CrudRepository<AccountEntity, Long> {
+public interface AccountJpaAdapter extends JpaRepository<AccountEntity, Long> {
 	Optional<AccountEntity> findByEmail(String email);
 
 	Boolean existsByEmail(String email);

--- a/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/cart/CartItemMapper.java
+++ b/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/cart/CartItemMapper.java
@@ -6,10 +6,17 @@ import com.academy.orders.infrastructure.cart.entity.CartItemEntity;
 import com.academy.orders.infrastructure.product.ProductMapper;
 import java.util.List;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
 
-@Mapper(componentModel = "spring", uses = ProductMapper.class)
+@Mapper(componentModel = "spring", uses = ProductMapper.class, unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface CartItemMapper {
+
+	@Mapping(target = "product.tags", ignore = true)
+	@Mapping(target = "product.productTranslations", ignore = true)
 	CartItem fromEntity(CartItemEntity cartItem);
 	CartItemEntity toEntity(CreateCartItemDTO cartItem);
+
 	List<CartItem> fromEntities(List<CartItemEntity> cartItemEntities);
+
 }

--- a/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/cart/repository/CartItemRepositoryImpl.java
+++ b/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/cart/repository/CartItemRepositoryImpl.java
@@ -42,11 +42,11 @@ public class CartItemRepositoryImpl implements CartItemRepository {
 	}
 
 	private void setProduct(CartItemEntity cartItemEntity, UUID productId) {
-		productJpaAdapter.findById(productId).ifPresent(cartItemEntity::setProduct);
+		cartItemEntity.setProduct(productJpaAdapter.getReferenceById(productId));
 	}
 
 	private void setAccount(CartItemEntity cartItemEntity, Long accountId) {
-		accountJpaAdapter.findById(accountId).ifPresent(cartItemEntity::setAccount);
+		cartItemEntity.setAccount(accountJpaAdapter.getReferenceById(accountId));
 	}
 
 	@Override

--- a/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/order/repository/OrderRepositoryImpl.java
+++ b/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/order/repository/OrderRepositoryImpl.java
@@ -6,7 +6,6 @@ import com.academy.orders.domain.order.repository.OrderRepository;
 import com.academy.orders.infrastructure.account.repository.AccountJpaAdapter;
 import com.academy.orders.infrastructure.order.OrderMapper;
 import com.academy.orders.infrastructure.order.entity.OrderEntity;
-import com.academy.orders.infrastructure.order.entity.OrderItemEntity;
 import com.academy.orders.infrastructure.product.repository.ProductJpaAdapter;
 import java.util.Optional;
 import java.util.UUID;
@@ -61,13 +60,13 @@ public class OrderRepositoryImpl implements OrderRepository {
 	}
 
 	private void addAccountToOrder(OrderEntity orderEntity, Long accountId) {
-		accountJpaAdapter.findById(accountId).ifPresent(orderEntity::setAccount);
+		orderEntity.setAccount(accountJpaAdapter.getReferenceById(accountId));
 	}
 
 	private void mapOrderItemsWithProductsAndOrder(OrderEntity orderEntity) {
-		for (OrderItemEntity item : orderEntity.getOrderItems()) {
-			productJpaAdapter.findById(item.getProduct().getId()).ifPresent(item::setProduct);
+		orderEntity.getOrderItems().forEach(item -> {
+			item.setProduct(productJpaAdapter.getReferenceById(item.getProduct().getId()));
 			item.setOrder(orderEntity);
-		}
+		});
 	}
 }

--- a/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/product/ProductMapper.java
+++ b/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/product/ProductMapper.java
@@ -3,24 +3,12 @@ package com.academy.orders.infrastructure.product;
 import com.academy.orders.domain.product.entity.Product;
 import com.academy.orders.infrastructure.product.entity.ProductEntity;
 import com.academy.orders.infrastructure.tag.TagMapper;
-import org.mapstruct.Mapper;
 import java.util.List;
-import org.mapstruct.IterableMapping;
-import org.mapstruct.Mapping;
-import org.mapstruct.Named;
-import org.mapstruct.ReportingPolicy;
+import org.mapstruct.Mapper;
 
-@Mapper(componentModel = "spring", uses = {TagMapper.class,
-		ProductTranslationMapper.class}, unmappedTargetPolicy = ReportingPolicy.IGNORE)
+@Mapper(componentModel = "spring", uses = {TagMapper.class, ProductTranslationMapper.class})
 public interface ProductMapper {
 	Product fromEntity(ProductEntity productEntity);
+
 	List<Product> fromEntities(List<ProductEntity> productEntities);
-
-	@Named("fromEntityWithoutJoin")
-	@Mapping(target = "tags", ignore = true)
-	@Mapping(target = "productTranslations", ignore = true)
-	Product fromEntityWithoutJoin(ProductEntity productEntities);
-
-	@IterableMapping(qualifiedByName = "fromEntityWithoutJoin")
-	List<Product> fromEntitiesWithoutJoin(List<ProductEntity> productEntities);
 }

--- a/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/product/repository/ProductJpaAdapter.java
+++ b/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/product/repository/ProductJpaAdapter.java
@@ -1,17 +1,17 @@
 package com.academy.orders.infrastructure.product.repository;
 
 import com.academy.orders.infrastructure.product.entity.ProductEntity;
+import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.CrudRepository;
-import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
 @Repository
-public interface ProductJpaAdapter extends CrudRepository<ProductEntity, UUID> {
+public interface ProductJpaAdapter extends JpaRepository<ProductEntity, UUID> {
 	@Query(value = "SELECT p FROM ProductEntity p JOIN FETCH p.productTranslations pt "
 			+ "JOIN FETCH pt.language l LEFT JOIN FETCH p.tags WHERE l.code = :language ORDER BY "
 			+ "CASE WHEN :sort = 'name,asc' THEN pt.name END ASC, "

--- a/code/orders-infrastructure/src/test/java/com/academy/orders/infrastructure/cart/repository/CartItemRepositoryImplTest.java
+++ b/code/orders-infrastructure/src/test/java/com/academy/orders/infrastructure/cart/repository/CartItemRepositoryImplTest.java
@@ -9,7 +9,6 @@ import com.academy.orders.infrastructure.cart.entity.CartItemEntity;
 import com.academy.orders.infrastructure.cart.entity.CartItemId;
 import com.academy.orders.infrastructure.product.entity.ProductEntity;
 import com.academy.orders.infrastructure.product.repository.ProductJpaAdapter;
-import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -73,8 +72,8 @@ class CartItemRepositoryImplTest {
 		var expected = CartItem.builder().product(productEntity).quantity(1).build();
 
 		when(cartItemMapper.toEntity(createCartItemDto)).thenReturn(cartItemEntity);
-		when(productJpaAdapter.findById(createCartItemDto.productId())).thenReturn(Optional.of(new ProductEntity()));
-		when(accountJpaAdapter.findById(createCartItemDto.userId())).thenReturn(Optional.of(new AccountEntity()));
+		when(productJpaAdapter.getReferenceById(createCartItemDto.productId())).thenReturn(new ProductEntity());
+		when(accountJpaAdapter.getReferenceById(createCartItemDto.userId())).thenReturn(new AccountEntity());
 		when(cartItemJpaAdapter.save(any(CartItemEntity.class))).thenReturn(cartItemEntity);
 		when(cartItemMapper.fromEntity(cartItemEntity)).thenReturn(expected);
 
@@ -85,8 +84,8 @@ class CartItemRepositoryImplTest {
 		assertNotNull(cartItemEntity.getProduct());
 
 		verify(cartItemMapper).toEntity(any(CreateCartItemDTO.class));
-		verify(productJpaAdapter).findById(any(UUID.class));
-		verify(accountJpaAdapter).findById(anyLong());
+		verify(productJpaAdapter).getReferenceById(any(UUID.class));
+		verify(accountJpaAdapter).getReferenceById(anyLong());
 		verify(cartItemJpaAdapter).save(any(CartItemEntity.class));
 		verify(cartItemMapper).fromEntity(any(CartItemEntity.class));
 	}

--- a/code/orders-infrastructure/src/test/java/com/academy/orders/infrastructure/order/repository/OrderRepositoryImplTest.java
+++ b/code/orders-infrastructure/src/test/java/com/academy/orders/infrastructure/order/repository/OrderRepositoryImplTest.java
@@ -8,7 +8,6 @@ import com.academy.orders.infrastructure.order.entity.OrderEntity;
 import com.academy.orders.infrastructure.product.entity.ProductEntity;
 import com.academy.orders.infrastructure.product.repository.ProductJpaAdapter;
 import java.util.Collections;
-import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -68,15 +67,15 @@ class OrderRepositoryImplTest {
 	private void setUpMocksForSaveMethod(OrderEntity orderEntity, AccountEntity accountEntity,
 			ProductEntity productEntity) {
 		when(mapper.toEntity(any(Order.class))).thenReturn(orderEntity);
-		when(accountJpaAdapter.findById(anyLong())).thenReturn(Optional.of(accountEntity));
-		when(productJpaAdapter.findById(any(UUID.class))).thenReturn(Optional.of(productEntity));
+		when(accountJpaAdapter.getReferenceById(anyLong())).thenReturn(accountEntity);
+		when(productJpaAdapter.getReferenceById(any(UUID.class))).thenReturn(productEntity);
 		when(jpaAdapter.save(any())).thenReturn(orderEntity);
 	}
 
 	private void verifyMocksOfSaveMethod() {
 		verify(mapper).toEntity(any(Order.class));
-		verify(accountJpaAdapter).findById(anyLong());
-		verify(productJpaAdapter).findById(any(UUID.class));
+		verify(accountJpaAdapter).getReferenceById(anyLong());
+		verify(productJpaAdapter).getReferenceById(any(UUID.class));
 		verify(jpaAdapter).save(any());
 	}
 }


### PR DESCRIPTION
## Issues
#105 

## Summary of changes 🔥
- Added AllowedAccountId to "create order" and "add the product to the cart" endpoint specifications.
- Improved tests to use Jwt principals.
- Used getReferenceById instead of findById in repository implementations.
- Used the bean of ObjectMapper instead of a simple object.
- Added security items to our swagger.
- Added transactions to the order-application module.