### PR TITLE
Update product status endpoint

### DIFF
--- a/code/orders-api-rest/api/openapi-rest.yml
+++ b/code/orders-api-rest/api/openapi-rest.yml
@@ -16,11 +16,14 @@ tags:
   - name: Products
     description: Products endpoint
 
+  - name: ProductsManagement
+    description: Endpoints for products management page
+
   - name: Orders
     description: Orders endpoints
 
   - name: OrdersManagement
-    description: Endpoints for management page
+    description: Endpoints for orders management page
 
   - name: Cart
     description: Cart management endpoints
@@ -216,6 +219,34 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '403':
           $ref: '#/components/responses/Forbidden'
+
+  /v1/management/products/{productId}/status:
+    patch:
+      tags:
+        - ProductsManagement
+      summary: Change visibility status for product
+      operationId: updateStatus
+#      security:
+#        - bearerAuth: [ ]
+      parameters:
+        - $ref: '#/components/parameters/ProductId'
+        - in: query
+          name: status
+          required: true
+          description: Visibility status for product
+          schema:
+            $ref: '#/components/schemas/ProductStatus'
+      responses:
+        '201':
+          description: successful operation
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
 
   /v1/products:
     get:
@@ -865,6 +896,14 @@ components:
           format: float
           example: 999.99
           description: Price of the product
+
+    ProductStatus:
+      type: string
+      enum:
+        - VISIBLE
+        - HIDDEN
+      example: VISIBLE
+      description: Status of the product's visibility for users
 
     PlaceOrderRequest:
       type: object

--- a/code/orders-api-rest/src/main/java/com/academy/orders/apirest/products/controller/ProductsController.java
+++ b/code/orders-api-rest/src/main/java/com/academy/orders/apirest/products/controller/ProductsController.java
@@ -20,7 +20,7 @@ import java.util.List;
 @RequiredArgsConstructor
 @Slf4j
 @CrossOrigin
-public class ProductController implements ProductsApi {
+public class ProductsController implements ProductsApi {
 	private final GetAllProductsUseCase getAllProductsUseCase;
 	private final ProductPreviewDTOMapper productPreviewDTOMapper;
 	private final PageableDTOMapper pageableDTOMapper;

--- a/code/orders-api-rest/src/main/java/com/academy/orders/apirest/products/controller/ProductsManagementController.java
+++ b/code/orders-api-rest/src/main/java/com/academy/orders/apirest/products/controller/ProductsManagementController.java
@@ -1,0 +1,28 @@
+package com.academy.orders.apirest.products.controller;
+
+import com.academy.orders.apirest.products.mapper.ProductStatusDTOMapper;
+import com.academy.orders.domain.product.entity.enumerated.ProductStatus;
+import com.academy.orders.domain.product.usecase.UpdateStatusUseCase;
+import com.academy.orders_api_rest.generated.api.ProductsManagementApi;
+import com.academy.orders_api_rest.generated.model.ProductStatusDTO;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+@CrossOrigin
+public class ProductsManagementController implements ProductsManagementApi {
+	private final UpdateStatusUseCase updateStatusUseCase;
+	private final ProductStatusDTOMapper productStatusDTOMapper;
+
+	@PreAuthorize("hasAnyAuthority('ROLE_MANAGER')")
+	public void updateStatus(UUID productId, ProductStatusDTO status) {
+		ProductStatus productStatus = productStatusDTOMapper.fromDTO(status);
+		updateStatusUseCase.updateStatus(productId, productStatus);
+	}
+}

--- a/code/orders-api-rest/src/main/java/com/academy/orders/apirest/products/controller/ProductsManagementController.java
+++ b/code/orders-api-rest/src/main/java/com/academy/orders/apirest/products/controller/ProductsManagementController.java
@@ -20,6 +20,7 @@ public class ProductsManagementController implements ProductsManagementApi {
 	private final UpdateStatusUseCase updateStatusUseCase;
 	private final ProductStatusDTOMapper productStatusDTOMapper;
 
+	@Override
 	@PreAuthorize("hasAnyAuthority('ROLE_MANAGER')")
 	public void updateStatus(UUID productId, ProductStatusDTO status) {
 		ProductStatus productStatus = productStatusDTOMapper.fromDTO(status);

--- a/code/orders-api-rest/src/main/java/com/academy/orders/apirest/products/mapper/ProductStatusDTOMapper.java
+++ b/code/orders-api-rest/src/main/java/com/academy/orders/apirest/products/mapper/ProductStatusDTOMapper.java
@@ -1,0 +1,10 @@
+package com.academy.orders.apirest.products.mapper;
+
+import com.academy.orders.domain.product.entity.enumerated.ProductStatus;
+import com.academy.orders_api_rest.generated.model.ProductStatusDTO;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface ProductStatusDTOMapper {
+	ProductStatus fromDTO(ProductStatusDTO productStatusDTO);
+}

--- a/code/orders-api-rest/src/test/java/com/academy/orders/apirest/common/TestSecurityConfig.java
+++ b/code/orders-api-rest/src/test/java/com/academy/orders/apirest/common/TestSecurityConfig.java
@@ -13,9 +13,7 @@ public class TestSecurityConfig {
 
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-		return http.csrf(AbstractHttpConfigurer::disable)
-				.authorizeHttpRequests(auth -> auth.requestMatchers("/auth/sign-in", "/auth/sign-up", "/v1/products/**")
-						.permitAll().anyRequest().authenticated())
+		return http.csrf(AbstractHttpConfigurer::disable).authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
 				.build();
 	}
 }

--- a/code/orders-api-rest/src/test/java/com/academy/orders/apirest/products/controller/ProductsControllerTest.java
+++ b/code/orders-api-rest/src/test/java/com/academy/orders/apirest/products/controller/ProductsControllerTest.java
@@ -27,10 +27,10 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(ProductController.class)
-@ContextConfiguration(classes = {ProductController.class})
-@Import(value = {ProductPreviewDTOMapper.class, AopAutoConfiguration.class, TestSecurityConfig.class})
-class ProductControllerTest {
+@WebMvcTest(ProductsController.class)
+@ContextConfiguration(classes = {ProductsController.class})
+@Import(value = {AopAutoConfiguration.class, TestSecurityConfig.class})
+class ProductsControllerTest {
 	@Autowired
 	private MockMvc mockMvc;
 

--- a/code/orders-api-rest/src/test/java/com/academy/orders/apirest/products/controller/ProductsManagementControllerTest.java
+++ b/code/orders-api-rest/src/test/java/com/academy/orders/apirest/products/controller/ProductsManagementControllerTest.java
@@ -28,7 +28,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(ProductsManagementController.class)
 @ContextConfiguration(classes = {ProductsManagementController.class})
 @Import(value = {AopAutoConfiguration.class, TestSecurityConfig.class})
-public class ProductsManagementControllerTest {
+class ProductsManagementControllerTest {
 	@Autowired
 	private MockMvc mockMvc;
 

--- a/code/orders-api-rest/src/test/java/com/academy/orders/apirest/products/controller/ProductsManagementControllerTest.java
+++ b/code/orders-api-rest/src/test/java/com/academy/orders/apirest/products/controller/ProductsManagementControllerTest.java
@@ -1,0 +1,62 @@
+package com.academy.orders.apirest.products.controller;
+
+import com.academy.orders.apirest.common.TestSecurityConfig;
+import com.academy.orders.apirest.products.mapper.ProductStatusDTOMapper;
+import com.academy.orders.domain.product.entity.enumerated.ProductStatus;
+import com.academy.orders.domain.product.usecase.UpdateStatusUseCase;
+import com.academy.orders_api_rest.generated.model.ProductStatusDTO;
+import java.util.UUID;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.aop.AopAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static com.academy.orders.apirest.TestConstants.TEST_UUID;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ProductsManagementController.class)
+@ContextConfiguration(classes = {ProductsManagementController.class})
+@Import(value = {AopAutoConfiguration.class, TestSecurityConfig.class})
+public class ProductsManagementControllerTest {
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockBean
+	private UpdateStatusUseCase updateStatusUseCase;
+
+	@MockBean
+	private ProductStatusDTOMapper productStatusDTOMapper;
+
+	@Test
+	@WithMockUser(authorities = {"ROLE_MANAGER"})
+	@SneakyThrows
+	void updateStatusTest() {
+		// Given
+		UUID productId = TEST_UUID;
+		ProductStatusDTO productStatusDTO = ProductStatusDTO.VISIBLE;
+		ProductStatus productStatus = ProductStatus.VISIBLE;
+
+		when(productStatusDTOMapper.fromDTO(productStatusDTO)).thenReturn(productStatus);
+		doNothing().when(updateStatusUseCase).updateStatus(productId, productStatus);
+
+		// When
+		mockMvc.perform(patch("/v1/management/products/{productId}/status", productId)
+				.param("status", productStatusDTO.getValue()).contentType(MediaType.APPLICATION_JSON))
+				.andExpect(status().isCreated());
+
+		// Then
+		verify(productStatusDTOMapper).fromDTO(productStatusDTO);
+		verify(updateStatusUseCase).updateStatus(productId, productStatus);
+	}
+}

--- a/code/orders-application/src/main/java/com/academy/orders/application/product/usecase/UpdateStatusUseCaseImpl.java
+++ b/code/orders-application/src/main/java/com/academy/orders/application/product/usecase/UpdateStatusUseCaseImpl.java
@@ -1,0 +1,25 @@
+package com.academy.orders.application.product.usecase;
+
+import com.academy.orders.domain.product.entity.enumerated.ProductStatus;
+import com.academy.orders.domain.product.exception.ProductNotFoundException;
+import com.academy.orders.domain.product.repository.ProductRepository;
+import com.academy.orders.domain.product.usecase.UpdateStatusUseCase;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UpdateStatusUseCaseImpl implements UpdateStatusUseCase {
+	private final ProductRepository productRepository;
+
+	@Override
+	@Transactional
+	public void updateStatus(UUID productId, ProductStatus status) {
+		if (!productRepository.existById(productId)) {
+			throw new ProductNotFoundException(productId);
+		}
+		productRepository.updateStatus(productId, status);
+	}
+}

--- a/code/orders-application/src/test/java/com/academy/orders/application/product/usecase/UpdateStatusUseCaseTest.java
+++ b/code/orders-application/src/test/java/com/academy/orders/application/product/usecase/UpdateStatusUseCaseTest.java
@@ -1,0 +1,54 @@
+package com.academy.orders.application.product.usecase;
+
+import com.academy.orders.domain.product.entity.enumerated.ProductStatus;
+import com.academy.orders.domain.product.exception.ProductNotFoundException;
+import com.academy.orders.domain.product.repository.ProductRepository;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static com.academy.orders.application.TestConstants.TEST_UUID;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UpdateStatusUseCaseTest {
+	@Mock
+	private ProductRepository productRepository;
+	@InjectMocks
+	private UpdateStatusUseCaseImpl updateStatusUseCase;
+
+	@Test
+	void testGetAllProductsTest() {
+		// Given
+		UUID productId = TEST_UUID;
+		ProductStatus status = ProductStatus.VISIBLE;
+
+		when(productRepository.existById(productId)).thenReturn(true);
+		doNothing().when(productRepository).updateStatus(productId, status);
+
+		// When
+		updateStatusUseCase.updateStatus(productId, status);
+
+		// Then
+		verify(productRepository).existById(productId);
+		verify(productRepository).updateStatus(productId, status);
+	}
+
+	@Test
+	void testGetAllProductsThrowProductNotFoundExceptionTest() {
+		// Given
+		UUID productId = TEST_UUID;
+		ProductStatus status = ProductStatus.VISIBLE;
+
+		when(productRepository.existById(productId)).thenReturn(false);
+
+		// Then
+		assertThrows(ProductNotFoundException.class, () -> updateStatusUseCase.updateStatus(productId, status));
+	}
+}

--- a/code/orders-domain/src/main/java/com/academy/orders/domain/product/repository/ProductRepository.java
+++ b/code/orders-domain/src/main/java/com/academy/orders/domain/product/repository/ProductRepository.java
@@ -3,6 +3,7 @@ package com.academy.orders.domain.product.repository;
 import com.academy.orders.domain.common.Page;
 import com.academy.orders.domain.common.Pageable;
 import com.academy.orders.domain.product.entity.Product;
+import com.academy.orders.domain.product.entity.enumerated.ProductStatus;
 import java.util.UUID;
 
 public interface ProductRepository {
@@ -30,4 +31,6 @@ public interface ProductRepository {
 	 * @author Denys Ryhal
 	 */
 	boolean existById(UUID id);
+
+	void updateStatus(UUID productId, ProductStatus status);
 }

--- a/code/orders-domain/src/main/java/com/academy/orders/domain/product/usecase/UpdateStatusUseCase.java
+++ b/code/orders-domain/src/main/java/com/academy/orders/domain/product/usecase/UpdateStatusUseCase.java
@@ -1,0 +1,8 @@
+package com.academy.orders.domain.product.usecase;
+
+import com.academy.orders.domain.product.entity.enumerated.ProductStatus;
+import java.util.UUID;
+
+public interface UpdateStatusUseCase {
+	void updateStatus(UUID productId, ProductStatus status);
+}

--- a/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/product/repository/ProductJpaAdapter.java
+++ b/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/product/repository/ProductJpaAdapter.java
@@ -1,5 +1,6 @@
 package com.academy.orders.infrastructure.product.repository;
 
+import com.academy.orders.domain.product.entity.enumerated.ProductStatus;
 import com.academy.orders.infrastructure.product.entity.ProductEntity;
 import java.util.List;
 import java.util.UUID;
@@ -9,7 +10,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
-import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 public interface ProductJpaAdapter extends JpaRepository<ProductEntity, UUID> {
@@ -31,7 +31,10 @@ public interface ProductJpaAdapter extends JpaRepository<ProductEntity, UUID> {
 	List<ProductEntity> findAllByIdAndLanguageCode(List<UUID> productIds, String language);
 
 	@Modifying
-	@Transactional
 	@Query(nativeQuery = true, value = "UPDATE products SET quantity = :quantity WHERE id = :id")
 	void setNewProductQuantity(UUID id, Integer quantity);
+
+	@Modifying
+	@Query(nativeQuery = true, value = "UPDATE products SET status = :status WHERE id = :id")
+	void updateProductStatus(UUID id, ProductStatus status);
 }

--- a/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/product/repository/ProductRepositoryImpl.java
+++ b/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/product/repository/ProductRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.academy.orders.infrastructure.product.repository;
 import com.academy.orders.domain.common.Page;
 import com.academy.orders.domain.common.Pageable;
 import com.academy.orders.domain.product.entity.Product;
+import com.academy.orders.domain.product.entity.enumerated.ProductStatus;
 import com.academy.orders.domain.product.repository.ProductRepository;
 import com.academy.orders.infrastructure.product.ProductMapper;
 import java.util.List;
@@ -11,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 @RequiredArgsConstructor
@@ -40,5 +42,10 @@ public class ProductRepositoryImpl implements ProductRepository {
 	@Override
 	public boolean existById(UUID id) {
 		return productJpaAdapter.existsById(id);
+	}
+
+	@Override
+	public void updateStatus(UUID productId, ProductStatus status) {
+		productJpaAdapter.updateProductStatus(productId, status);
 	}
 }

--- a/code/orders-infrastructure/src/test/java/com/academy/orders/infrastructure/product/repository/ProductRepositoryImplTest.java
+++ b/code/orders-infrastructure/src/test/java/com/academy/orders/infrastructure/product/repository/ProductRepositoryImplTest.java
@@ -1,5 +1,6 @@
 package com.academy.orders.infrastructure.product.repository;
 
+import com.academy.orders.domain.product.entity.enumerated.ProductStatus;
 import java.util.List;
 import java.util.UUID;
 import com.academy.orders.infrastructure.product.ProductMapper;
@@ -15,6 +16,7 @@ import org.springframework.data.domain.PageRequest;
 import static com.academy.orders.infrastructure.ModelUtils.getPageable;
 import static com.academy.orders.infrastructure.ModelUtils.getProduct;
 import static com.academy.orders.infrastructure.ModelUtils.getProductEntity;
+import static com.academy.orders.infrastructure.TestConstants.TEST_UUID;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.*;
@@ -65,5 +67,17 @@ class ProductRepositoryImplTest {
 		verify(productJpaAdapter).findAllByLanguageCodeAndStatusVisible("en",
 				PageRequest.of(pageable.page(), pageable.size()), sort);
 		verify(productMapper).fromEntities(page.getContent());
+	}
+
+	@Test
+	void updateStatusTest() {
+		UUID productId = TEST_UUID;
+		ProductStatus status = ProductStatus.VISIBLE;
+
+		doNothing().when(productJpaAdapter).updateProductStatus(productId, status);
+
+		productRepository.updateStatus(productId, status);
+
+		verify(productJpaAdapter).updateProductStatus(productId, status);
 	}
 }


### PR DESCRIPTION
## Task
[#184](https://github.com/idx-academy/mic-orders/issues/184)
## Changes
- Added endpoint for manager to set status for product (VISIBLE / HIDDEN)
- Covered new functionality by unit tests unit tests
- Edited name of ProductsController
- Added new ProdcutsManagementController and openapi specifications